### PR TITLE
Config updates for staff search dir.

### DIFF
--- a/sites/default/config/search_api.index.staff.yml
+++ b/sites/default/config/search_api.index.staff.yml
@@ -13,8 +13,10 @@ dependencies:
     - field.storage.user.field_role
     - field.storage.user.field_team
     - field.storage.user.field_languages
+    - field.storage.user.field_first_name
     - search_api.server.default_server
   module:
+    - taxonomy
     - search_api
     - user
 id: staff
@@ -22,11 +24,6 @@ name: Staff
 description: ''
 read_only: false
 field_settings:
-  search_api_language:
-    label: 'Item language'
-    datasource_id: null
-    property_path: search_api_language
-    type: string
   uid:
     label: 'User ID'
     datasource_id: 'entity:user'
@@ -108,10 +105,68 @@ field_settings:
     label: Languages
     datasource_id: 'entity:user'
     property_path: field_languages
-    type: integer
+    type: string
     dependencies:
       config:
         - field.storage.user.field_languages
+  name:
+    label: 'Subject Specialty » Taxonomy term » Name'
+    datasource_id: 'entity:user'
+    property_path: 'field_subject_specialty:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.user.field_subject_specialty
+      module:
+        - taxonomy
+  name_1:
+    label: 'Library » Taxonomy term » Name'
+    datasource_id: 'entity:user'
+    property_path: 'field_library:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.user.field_library
+      module:
+        - taxonomy
+  processed:
+    label: 'First Name » Processed text'
+    datasource_id: 'entity:user'
+    property_path: 'field_first_name:processed'
+    type: text
+    dependencies:
+      config:
+        - field.storage.user.field_first_name
+  name_2:
+    label: 'Team » Taxonomy term » Name'
+    datasource_id: 'entity:user'
+    property_path: 'field_team:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.user.field_team
+      module:
+        - taxonomy
+  name_3:
+    label: 'Technology Specialty » Taxonomy term » Name'
+    datasource_id: 'entity:user'
+    property_path: 'field_technology_specialty:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.user.field_technology_specialty
+      module:
+        - taxonomy
+  name_4:
+    label: 'Department » Taxonomy term » Name'
+    datasource_id: 'entity:user'
+    property_path: 'field_department:entity:name'
+    type: text
+    dependencies:
+      config:
+        - field.storage.user.field_department
+      module:
+        - taxonomy
 processor_settings:
   add_url:
     plugin_id: add_url
@@ -126,6 +181,21 @@ processor_settings:
         staff: staff
       weights:
         preprocess_index: -10
+  ignorecase:
+    plugin_id: ignorecase
+    settings:
+      fields:
+        - field_pennkey
+        - field_languages
+        - name
+        - name_1
+        - processed
+        - name_2
+        - name_3
+        - name_4
+      weights:
+        preprocess_index: -10
+        preprocess_query: -10
 options:
   index_directly: true
   cron_limit: 50

--- a/sites/default/config/views.view.staff_search.yml
+++ b/sites/default/config/views.view.staff_search.yml
@@ -3,9 +3,13 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.user.field_library
+    - field.storage.user.field_pennkey
+    - field.storage.user.field_role
     - search_api.index.staff
   module:
     - search_api
+    - text
     - user
 id: staff_search
 label: 'Staff Search'
@@ -48,7 +52,7 @@ display:
       pager:
         type: full
         options:
-          items_per_page: 25
+          items_per_page: 5
           offset: 0
           id: 0
           total_pages: null
@@ -58,9 +62,9 @@ display:
             first: '« First'
             last: 'Last »'
           expose:
-            items_per_page: true
+            items_per_page: false
             items_per_page_label: 'Items per page'
-            items_per_page_options: '25, 50, 100'
+            items_per_page_options: '5'
             items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
@@ -646,7 +650,50 @@ display:
                 display_method: label
           entity_type: user
           plugin_id: search_api_field
-      filters: {  }
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_staff
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            identifier: search_api_fulltext
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              staff: '0'
+              hr_department: '0'
+              web_admin: '0'
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          min_length: null
+          fields: {  }
+          plugin_id: search_api_fulltext
       sorts: {  }
       title: 'Staff Search'
       header: {  }
@@ -656,13 +703,18 @@ display:
       arguments: {  }
       display_extenders: {  }
       css_class: staff-search-wrapper
+      use_ajax: true
     cache_metadata:
       max-age: 0
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.user.field_library'
+        - 'config:field.storage.user.field_pennkey'
+        - 'config:field.storage.user.field_role'
   block_1:
     display_plugin: block
     id: block_1
@@ -678,7 +730,11 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.user.field_library'
+        - 'config:field.storage.user.field_pennkey'
+        - 'config:field.storage.user.field_role'


### PR DESCRIPTION
Will need more configuration and styling. To make this work you need to drush config-import and then reindex the staff search from the search api. Also if users do not have options selected - such as "subject speciality" no results will show in the facet blocks. 